### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ sqlgrey (1:1.8.0-5) UNRELEASED; urgency=medium
   * Trim trailing whitespace.
   * Use secure URI in debian/watch.
   * Set upstream metadata fields: Repository.
+  * Use secure URI in Vcs control header Vcs-Git.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 02:48:35 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+sqlgrey (1:1.8.0-5) UNRELEASED; urgency=medium
+
+  * Trim trailing whitespace.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 02:48:35 +0000
+
 sqlgrey (1:1.8.0-4) unstable; urgency=medium
 
   * Bumping version to allow for source only upload. (Kudos to Andrian Bunk
@@ -60,4 +66,3 @@ sqlgrey (1.6.8-1) unstable; urgency=low
   * Initial release (Closes: #389472)
 
  -- Antonin Kral <A.Kral@sh.cvut.cz>  Wed, 19 Mar 2008 21:18:15 +0100
-

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 sqlgrey (1:1.8.0-5) UNRELEASED; urgency=medium
 
   * Trim trailing whitespace.
+  * Use secure URI in debian/watch.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 02:48:35 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ sqlgrey (1:1.8.0-5) UNRELEASED; urgency=medium
 
   * Trim trailing whitespace.
   * Use secure URI in debian/watch.
+  * Set upstream metadata fields: Repository.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 02:48:35 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,7 @@ sqlgrey (1:1.8.0-5) UNRELEASED; urgency=medium
   * Use secure URI in debian/watch.
   * Set upstream metadata fields: Repository.
   * Use secure URI in Vcs control header Vcs-Git.
+  * Update standards version to 4.5.0, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 02:48:35 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Antonin Kral <A.Kral@sh.cvut.cz>
 Build-Depends: debhelper (>= 5), perl-doc, debhelper-compat (= 12), dh-exec
 Standards-Version: 4.4.1
-Vcs-Git: git://github.com/bobek/sqlgrey-debian.git
+Vcs-Git: https://github.com/bobek/sqlgrey-debian.git
 Vcs-Browser: https://github.com/bobek/sqlgrey-debian
 Homepage: http://sqlgrey.sourceforge.net/
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: mail
 Priority: optional
 Maintainer: Antonin Kral <A.Kral@sh.cvut.cz>
 Build-Depends: debhelper (>= 5), perl-doc, debhelper-compat (= 12), dh-exec
-Standards-Version: 4.4.1
+Standards-Version: 4.5.0
 Vcs-Git: https://github.com/bobek/sqlgrey-debian.git
 Vcs-Browser: https://github.com/bobek/sqlgrey-debian
 Homepage: http://sqlgrey.sourceforge.net/

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,1 @@
+Repository: https://git.code.sf.net/p/sqlgrey/code

--- a/debian/watch
+++ b/debian/watch
@@ -1,4 +1,4 @@
 version=3
-http://sf.net/sqlgrey/sqlgrey-(.*)\.tar\.gz
+https://sf.net/sqlgrey/sqlgrey-(.*)\.tar\.gz
 
 


### PR DESCRIPTION
Fix some issues reported by lintian
* Trim trailing whitespace. ([file-contains-trailing-whitespace](https://lintian.debian.org/tags/file-contains-trailing-whitespace.html))
* Use secure URI in debian/watch. ([debian-watch-uses-insecure-uri](https://lintian.debian.org/tags/debian-watch-uses-insecure-uri.html))
* Set upstream metadata fields: Repository. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))
* Use secure URI in Vcs control header Vcs-Git. ([vcs-field-uses-insecure-uri](https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html))
* Update standards version to 4.5.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/sqlgrey/410592e8-5a7f-4329-ae91-1a1e2c45b33d.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/410592e8-5a7f-4329-ae91-1a1e2c45b33d/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/410592e8-5a7f-4329-ae91-1a1e2c45b33d/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/410592e8-5a7f-4329-ae91-1a1e2c45b33d/diffoscope)).
